### PR TITLE
bump oauth2 version

### DIFF
--- a/pokitdok-ruby.gemspec
+++ b/pokitdok-ruby.gemspec
@@ -68,7 +68,7 @@ Gem::Specification.new do |s|
     s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<oauth2>, ["~> 0.9"])
+      s.add_runtime_dependency(%q<oauth2>, ["~> 1.0"])
       s.add_runtime_dependency(%q<multipart-post>, ["~> 2.0"])
       s.add_development_dependency(%q<bundler>, ["~> 1.0"])
       s.add_development_dependency(%q<minitest>, ["~> 5.3"])
@@ -88,7 +88,7 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<guard-rubocop>, ["~> 1.0"])
       s.add_development_dependency(%q<coveralls>, [">= 0"])
     else
-      s.add_dependency(%q<oauth2>, ["~> 0.9"])
+      s.add_dependency(%q<oauth2>, ["~> 1.0"])
       s.add_dependency(%q<multipart-post>, ["~> 2.0"])
       s.add_dependency(%q<bundler>, ["~> 1.0"])
       s.add_dependency(%q<minitest>, ["~> 5.3"])
@@ -109,7 +109,7 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<coveralls>, [">= 0"])
     end
   else
-    s.add_dependency(%q<oauth2>, ["~> 0.9"])
+    s.add_dependency(%q<oauth2>, ["~> 1.0"])
     s.add_dependency(%q<multipart-post>, ["~> 2.0"])
     s.add_dependency(%q<bundler>, ["~> 1.0"])
     s.add_dependency(%q<minitest>, ["~> 5.3"])


### PR DESCRIPTION
Other gems we're using have oauth2 1.0 specified (ie, https://github.com/zquestz/omniauth-google-oauth2). The difference between oauth2's 0.9.4 and 1.0 versions look to be just adding MAC token support - but otherwise seem rather unobtrusive to anything in this gem.
See https://github.com/intridea/oauth2/compare/277bd71...3d62127 for a comparison view.

So, bumping up oauth2 version shouldn't have any side effects from what I can tell. 