### PR TITLE
PLATFORM-3810 : Ruby Client - Implement ICD Convert

### DIFF
--- a/lib/pokitdok.rb
+++ b/lib/pokitdok.rb
@@ -99,6 +99,15 @@ module PokitDok
       post('claims/status', params)
     end
 
+    # Invokes the ICD convert endpoint.
+    #
+    # +params+ an optional hash of parameters
+    #
+    def icd_convert(params = {})
+      scope 'default'
+      get("icd/convert/#{params[:code]}")
+    end
+
     # Invokes the eligibility endpoint.
     #
     # +params+ an optional hash of parameters that will be sent in the POST body

--- a/pokitdok-ruby.gemspec
+++ b/pokitdok-ruby.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |s|
   ]
   s.homepage = "http://github.com/pokitdok/pokitdok-ruby"
   s.licenses = ["MIT"]
-  s.rubygems_version = "2.5.1"
+  s.rubygems_version = "2.4.8"
   s.summary = "Gem for easy access to the PokitDok Platform APIs"
 
   if s.respond_to? :specification_version then

--- a/spec/pokitdok_spec.rb
+++ b/spec/pokitdok_spec.rb
@@ -97,7 +97,15 @@ describe PokitDok do
 
     # TODO: MPC Tests
 
-    # TODO: ICD Convert Tests
+    describe 'ICD Convert endpoint' do
+      it 'should expose the icd convert endpoint' do
+        stub_request(:get, MATCH_NETWORK_LOCATION).
+            to_return(status: 200, body: '{ "string" : "" }')
+
+        @icd = @pokitdok.icd_convert(code: '250.12')
+        refute_nil(@icd)
+      end
+    end
 
     # TODO: Claims Convert Tests
 


### PR DESCRIPTION
Completion of ticket [PLATFORM-3810](https://pokitdok.atlassian.net/browse/PLATFORM-3810) which entailed the implementation of the /icd/convert/ endpoint and its corresponding test. 