### PR TITLE
PLATFORM-3813 : Ruby Client - Implement /schedule/slots/

### DIFF
--- a/lib/pokitdok.rb
+++ b/lib/pokitdok.rb
@@ -352,8 +352,9 @@ module PokitDok
     #    
     # +params+ an optional Hash of parameters
     #
-    def slots(params = {})
+    def schedule_slots(params = {})
       scope 'user_schedule'
+      post('/schedule/slots/', params)
     end
 
     # Invokes the pharmacy plans endpoint.

--- a/pokitdok-ruby.gemspec
+++ b/pokitdok-ruby.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib"]
   s.authors = ["PokitDok, Inc."]
-  s.date = "2016-06-28"
+  s.date = "2016-06-30"
   s.description = "Gem for easy access to the PokitDok Platform APIs."
   s.email = "platform@pokitdok.com"
   s.extra_rdoc_files = [

--- a/spec/pokitdok_spec.rb
+++ b/spec/pokitdok_spec.rb
@@ -14,22 +14,22 @@ describe PokitDok do
   describe 'Authenticated functions' do
     before do
       stub_request(:post, /#{MATCH_NETWORK_LOCATION}#{MATCH_OAUTH2_PATH}/).
-          to_return(
-              :status => 200,
-              :body => '{
-              "access_token": "s8KYRJGTO0rWMy0zz1CCSCwsSesDyDlbNdZoRqVR",
-              "token_type": "bearer",
-              "expires": 1393350569,
-              "expires_in": 3600
-            }',
-              :headers => {
-                  'Server'=> 'nginx',
-                  'Date' => Time.now(),
-                  'Content-type' => 'application/json;charset=UTF-8',
-                  'Connection' => 'keep-alive',
-                  'Pragma' => 'no-cache',
-                  'Cache-Control' => 'no-store'
-              })
+        to_return(
+          :status => 200,
+          :body => '{
+            "access_token": "s8KYRJGTO0rWMy0zz1CCSCwsSesDyDlbNdZoRqVR",
+            "token_type": "bearer",
+            "expires": 1393350569,
+            "expires_in": 3600
+          }',
+          :headers => {
+            'Server'=> 'nginx',
+            'Date' => Time.now(),
+            'Content-type' => 'application/json;charset=UTF-8',
+            'Connection' => 'keep-alive',
+            'Pragma' => 'no-cache',
+            'Cache-Control' => 'no-store'
+          })
 
       @pokitdok = PokitDok::PokitDok.new(CLIENT_ID, CLIENT_SECRET)
       @pokitdok.scope_code('user_schedule', SCHEDULE_AUTH_CODE)

--- a/spec/pokitdok_spec.rb
+++ b/spec/pokitdok_spec.rb
@@ -15,21 +15,21 @@ describe PokitDok do
     before do
       stub_request(:post, /#{MATCH_NETWORK_LOCATION}#{MATCH_OAUTH2_PATH}/).
           to_return(
-            :status => 200,
-            :body => '{
+              :status => 200,
+              :body => '{
               "access_token": "s8KYRJGTO0rWMy0zz1CCSCwsSesDyDlbNdZoRqVR",
               "token_type": "bearer",
               "expires": 1393350569,
               "expires_in": 3600
             }',
-            :headers => {
-              'Server'=> 'nginx',
-              'Date' => Time.now(),
-              'Content-type' => 'application/json;charset=UTF-8',
-              'Connection' => 'keep-alive',
-              'Pragma' => 'no-cache',
-              'Cache-Control' => 'no-store'
-            })
+              :headers => {
+                  'Server'=> 'nginx',
+                  'Date' => Time.now(),
+                  'Content-type' => 'application/json;charset=UTF-8',
+                  'Connection' => 'keep-alive',
+                  'Pragma' => 'no-cache',
+                  'Cache-Control' => 'no-store'
+              })
 
       @pokitdok = PokitDok::PokitDok.new(CLIENT_ID, CLIENT_SECRET)
       @pokitdok.scope_code('user_schedule', SCHEDULE_AUTH_CODE)
@@ -333,7 +333,11 @@ describe PokitDok do
       end
 
       it 'should create an open schedule slot' do
-        stub_request(:post, MATCH_NETWORK_LOCATION).
+        # Special Case: The scheduling endpoint reauthenticates for the scope (user_schedule),
+        # which would be caught by the below 'stub_request'. This would cause the OAuth module
+        # to fail because of an empty return body (to see what is required on an OAuth) POST
+        # refer to the 'before' code block above. This 'stub_request' will only catch the /schedule/slots/ request.
+        stub_request(:post,/#{MATCH_NETWORK_LOCATION}\/schedule\/slots/).
             to_return(status: 200, body: '{ "string" : "" }')
 
         query = {

--- a/spec/pokitdok_spec.rb
+++ b/spec/pokitdok_spec.rb
@@ -332,7 +332,21 @@ describe PokitDok do
         refute_nil(@appointment_type)
       end
 
-      # TODO: /schedule/slots test
+      it 'should create an open schedule slot' do
+        stub_request(:post, MATCH_NETWORK_LOCATION).
+            to_return(status: 200, body: '{ "string" : "" }')
+
+        query = {
+            pd_provider_uuid: "b691b7f9-bfa8-486d-a689-214ae47ea6f8",
+            location: [32.788110, -79.932364],
+            appointment_type: "AT1",
+            start_date: "2014-12-25T15:09:34.197709",
+            end_date: "2014-12-25T16:09:34.197717"
+        }
+        @slot = @pokitdok.schedule_slots(query)
+
+        refute_nil(@slot)
+      end
 
       it 'should give details on a specific appointment' do
         stub_request(:get, MATCH_NETWORK_LOCATION).


### PR DESCRIPTION
Completion of [PLATFORM-3813](https://pokitdok.atlassian.net/browse/PLATFORM-3813) which entailed the implementation of the `/schedule/slots/` endpoint and its corresponding test. 