### PR TITLE
PLATFORM-5398 adapt for oauth2 1.3 breaking changes

### DIFF
--- a/lib/OAuthApplicationClient.rb
+++ b/lib/OAuthApplicationClient.rb
@@ -122,13 +122,12 @@ class OAuthApplicationClient
     if code
       # Currently non functioning as our OAuth2 authorization_code grant type is not implemented on the server
       params =  {
-          headers: { 'Authorization' => 'Basic' },
           scope: @scope,
           redirect_uri: @redirect_uri
       }
       @token = @api_client.auth_code.get_token(code, params)
     else
-      @token = @api_client.client_credentials.get_token(headers: { 'Authorization' => 'Basic' })
+      @token = @api_client.client_credentials.get_token()
     end
   end
 


### PR DESCRIPTION
oauth2 version 1.3 introduced breaking changes.
https://github.com/intridea/oauth2/blob/master/CHANGELOG.md#130---2016-12-28
The following change is compatible with 1.3 and still works with lower versions.